### PR TITLE
Fix: Add cookies permission and implement session storage commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,39 @@ Error:
 }
 ```
 
+**tabs.getSessionStorage** - Get sessionStorage
+```json
+{
+  "command": "tabs.getSessionStorage",
+  "params": {
+    "tabId": 123,
+    "key": "temp_data"
+  }
+}
+```
+
+**tabs.setSessionStorage** - Set sessionStorage
+```json
+{
+  "command": "tabs.setSessionStorage",
+  "params": {
+    "tabId": 123,
+    "key": "temp_data",
+    "value": "{\"sessionId\":\"abc123\"}"
+  }
+}
+```
+
+**tabs.clearSessionStorage** - Clear all sessionStorage
+```json
+{
+  "command": "tabs.clearSessionStorage",
+  "params": {
+    "tabId": 123
+  }
+}
+```
+
 #### Utilities
 
 **tabs.waitForElement** - Wait for element to appear

--- a/README.md
+++ b/README.md
@@ -308,6 +308,17 @@ Error:
 }
 ```
 
+**tabs.deleteCookie** - Delete a cookie
+```json
+{
+  "command": "tabs.deleteCookie",
+  "params": {
+    "url": "https://example.com",
+    "name": "session_id"
+  }
+}
+```
+
 **tabs.getLocalStorage** - Get localStorage
 ```json
 {
@@ -327,6 +338,16 @@ Error:
     "tabId": 123,
     "key": "user_preferences",
     "value": "{\"theme\":\"dark\"}"
+  }
+}
+```
+
+**tabs.clearLocalStorage** - Clear all localStorage
+```json
+{
+  "command": "tabs.clearLocalStorage",
+  "params": {
+    "tabId": 123
   }
 }
 ```

--- a/background.js
+++ b/background.js
@@ -26,7 +26,10 @@ const commandHandlers = {
   'tabs.deleteCookie': handleDeleteCookie,
   'tabs.getLocalStorage': handleGetLocalStorage,
   'tabs.setLocalStorage': handleSetLocalStorage,
-  'tabs.clearLocalStorage': handleClearLocalStorage
+  'tabs.clearLocalStorage': handleClearLocalStorage,
+  'tabs.getSessionStorage': handleGetSessionStorage,
+  'tabs.setSessionStorage': handleSetSessionStorage,
+  'tabs.clearSessionStorage': handleClearSessionStorage
 };
 
 function connectWebSocket() {
@@ -408,6 +411,43 @@ async function handleClearLocalStorage(params) {
     target: { tabId: params.tabId },
     func: () => {
       localStorage.clear();
+      return true;
+    }
+  });
+  return { success: results[0]?.result || false };
+}
+
+async function handleGetSessionStorage(params) {
+  const results = await chrome.scripting.executeScript({
+    target: { tabId: params.tabId },
+    func: (key) => {
+      if (key) {
+        return { [key]: sessionStorage.getItem(key) };
+      }
+      return { ...sessionStorage };
+    },
+    args: [params.key]
+  });
+  return { storage: results[0]?.result };
+}
+
+async function handleSetSessionStorage(params) {
+  const results = await chrome.scripting.executeScript({
+    target: { tabId: params.tabId },
+    func: (key, value) => {
+      sessionStorage.setItem(key, value);
+      return true;
+    },
+    args: [params.key, params.value]
+  });
+  return { success: results[0]?.result || false };
+}
+
+async function handleClearSessionStorage(params) {
+  const results = await chrome.scripting.executeScript({
+    target: { tabId: params.tabId },
+    func: () => {
+      sessionStorage.clear();
       return true;
     }
   });

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
     "activeTab",
     "scripting",
     "storage",
+    "cookies",
     "debugger",
     "webNavigation",
     "pageCapture",


### PR DESCRIPTION
## Summary
- Added missing 'cookies' permission to manifest.json to enable cookie API functionality
- Documented missing `tabs.deleteCookie` command in README.md
- Documented missing `tabs.clearLocalStorage` command in README.md
- **NEW:** Implemented complete session storage support with three new commands:
  - `tabs.getSessionStorage` - Get sessionStorage values
  - `tabs.setSessionStorage` - Set sessionStorage values
  - `tabs.clearSessionStorage` - Clear all sessionStorage

## Context
The cookie and storage commands were already implemented in the codebase but:
1. The 'cookies' permission was missing from manifest.json, preventing cookie commands from working
2. Two commands (`tabs.deleteCookie` and `tabs.clearLocalStorage`) were not documented in the README
3. Session storage commands were completely missing and have now been added

## Implementation Details
Session storage commands follow the same pattern as localStorage commands:
- Use `chrome.scripting.executeScript` to access sessionStorage in the target tab
- Support getting individual keys or all sessionStorage data
- Return consistent response formats matching localStorage commands

## Test plan
- [ ] Verify the extension loads without errors after adding the cookies permission
- [ ] Test that cookie commands (getCookies, setCookie, deleteCookie) work correctly
- [ ] Verify localStorage commands continue to work as expected
- [ ] Test new sessionStorage commands:
  - [ ] `tabs.getSessionStorage` retrieves values correctly
  - [ ] `tabs.setSessionStorage` sets values correctly
  - [ ] `tabs.clearSessionStorage` clears all session data
- [ ] Confirm the README documentation is accurate and complete