### PR TITLE
fix: remove <all_urls> from permissions array in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,8 +13,7 @@
     "webNavigation",
     "pageCapture",
     "tabCapture",
-    "desktopCapture",
-    "<all_urls>"
+    "desktopCapture"
   ],
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
## Summary
- Remove `<all_urls>` from the permissions array in manifest.json
- Keep `<all_urls>` only in host_permissions as required by Chrome Manifest V3

## Context
In Chrome Manifest V3, host pattern permissions like `<all_urls>` should only be declared in the `host_permissions` array, not in the `permissions` array. The permissions array is specifically for API permissions.

## Changes
- Removed `"<all_urls>"` from the permissions array (line 17)
- Kept it in the host_permissions array where it belongs

## Test plan
- [ ] Install the extension in Chrome
- [ ] Verify no manifest validation errors appear
- [ ] Confirm extension functionality remains unchanged
- [ ] Check that content scripts still inject on all URLs