### PR TITLE
fix: handle undefined index parameter in click command

### DIFF
--- a/background.js
+++ b/background.js
@@ -282,7 +282,7 @@ async function handleClick(params) {
       }
       return false;
     },
-    args: [params.selector, params.index]
+    args: [params.selector, params.index || 0]
   });
   return { success: results[0]?.result || false };
 }


### PR DESCRIPTION
## Summary
- Fixed Chrome extension error when clicking elements without specifying an index
- Ensures the index parameter defaults to 0 when undefined to prevent serialization errors

## Problem
The extension was throwing the error:
```
Failed to click: chrome extension error: Error in invocation of scripting.executeScript(scripting.ScriptInjection injection, optional function callback): Error at parameter 'injection': Error at property 'args': Error at index 1: Value is unserializable.
```

This occurred because `params.index` could be `undefined`, which cannot be serialized when passed through Chrome's extension messaging system.

## Solution
Changed the args array in `handleClick` function from:
```javascript
args: [params.selector, params.index]
```
to:
```javascript
args: [params.selector, params.index || 0]
```

This ensures that we always pass a serializable number (defaulting to 0) instead of potentially passing `undefined`.

## Test Plan
- [x] All existing tests pass
- [x] Linting passes with no errors
- [ ] Manual testing: Click commands work both with and without index parameter