### PR TITLE
fix: handle undefined append parameter in type command

### DIFF
--- a/background.js
+++ b/background.js
@@ -304,7 +304,7 @@ async function handleType(params) {
       }
       return false;
     },
-    args: [params.selector, params.text, params.append]
+    args: [params.selector, params.text, params.append || false]
   });
   return { success: results[0]?.result || false };
 }


### PR DESCRIPTION
## Summary
- Fixed scripting.executeScript error when params.append is undefined
- Added default value of false for the append parameter to prevent serialization issues

## Test plan
- [ ] Test the type command with append parameter explicitly set to true
- [ ] Test the type command with append parameter explicitly set to false  
- [ ] Test the type command without append parameter (should default to false)
- [ ] Verify no serialization errors occur in all cases