### PR TITLE
Improve accessibility snapshot error handling and add test files

### DIFF
--- a/content.js
+++ b/content.js
@@ -700,7 +700,15 @@ function getAccessibilitySnapshot(params, id) {
 function initializeConnection() {
   // Check if we're in a valid context
   if (typeof chrome === 'undefined' || !chrome.runtime || !chrome.runtime.id) {
-    console.error('Extension context not available');
+    console.warn('Extension context not available - might be on a restricted page (chrome://, chrome-extension://, etc.)');
+    return;
+  }
+  
+  // Additional check for restricted URLs
+  const restrictedProtocols = ['chrome:', 'chrome-extension:', 'edge:', 'about:', 'data:', 'file:'];
+  const currentProtocol = window.location.protocol;
+  if (restrictedProtocols.includes(currentProtocol)) {
+    console.warn(`Content script cannot run on ${currentProtocol} pages`);
     return;
   }
   

--- a/test-accessibility-snapshot.js
+++ b/test-accessibility-snapshot.js
@@ -1,0 +1,85 @@
+// Test script for tabs.getAccessibilitySnapshot
+// This can be run from the WebSocket client to test the functionality
+
+async function testAccessibilitySnapshot() {
+  console.log('Testing tabs.getAccessibilitySnapshot...\n');
+  
+  // Test 1: Basic snapshot with default parameters
+  console.log('Test 1: Basic accessibility snapshot');
+  try {
+    const response1 = await sendCommand('tabs.getAccessibilitySnapshot', {
+      tabId: 1  // Replace with actual tab ID
+    });
+    console.log('✓ Basic snapshot:', JSON.stringify(response1.snapshot, null, 2));
+  } catch (error) {
+    console.error('✗ Basic snapshot failed:', error);
+  }
+  
+  // Test 2: Snapshot with interestingOnly = false
+  console.log('\nTest 2: Full accessibility tree (interestingOnly = false)');
+  try {
+    const response2 = await sendCommand('tabs.getAccessibilitySnapshot', {
+      tabId: 1,  // Replace with actual tab ID
+      interestingOnly: false
+    });
+    console.log('✓ Full tree snapshot:', JSON.stringify(response2.snapshot, null, 2));
+  } catch (error) {
+    console.error('✗ Full tree snapshot failed:', error);
+  }
+  
+  // Test 3: Snapshot with specific root selector
+  console.log('\nTest 3: Snapshot with root selector');
+  try {
+    const response3 = await sendCommand('tabs.getAccessibilitySnapshot', {
+      tabId: 1,  // Replace with actual tab ID
+      root: '#main-content'
+    });
+    console.log('✓ Root selector snapshot:', JSON.stringify(response3.snapshot, null, 2));
+  } catch (error) {
+    console.error('✗ Root selector snapshot failed:', error);
+  }
+  
+  // Test 4: Invalid tab ID
+  console.log('\nTest 4: Invalid tab ID (error handling)');
+  try {
+    const response4 = await sendCommand('tabs.getAccessibilitySnapshot', {
+      tabId: 99999
+    });
+    console.log('✗ Should have failed with invalid tab ID');
+  } catch (error) {
+    console.log('✓ Correctly handled error:', error);
+  }
+  
+  // Test 5: Non-existent root selector
+  console.log('\nTest 5: Non-existent root selector');
+  try {
+    const response5 = await sendCommand('tabs.getAccessibilitySnapshot', {
+      tabId: 1,  // Replace with actual tab ID
+      root: '#non-existent-element'
+    });
+    console.log('Result:', response5.snapshot);
+    if (!response5.snapshot) {
+      console.log('✓ Correctly returned null for non-existent root');
+    }
+  } catch (error) {
+    console.error('✗ Non-existent root failed:', error);
+  }
+}
+
+// Helper function to send WebSocket command (placeholder)
+async function sendCommand(command, params) {
+  // This would be implemented by the WebSocket client
+  console.log(`Sending command: ${command}`, params);
+  // Return mock response for testing
+  return { 
+    snapshot: { 
+      role: 'document',
+      children: []
+    } 
+  };
+}
+
+// Run tests if this script is executed directly
+if (typeof module === 'undefined') {
+  testAccessibilitySnapshot();
+}

--- a/test-accessibility-snapshot.js
+++ b/test-accessibility-snapshot.js
@@ -42,7 +42,7 @@ async function testAccessibilitySnapshot() {
   // Test 4: Invalid tab ID
   console.log('\nTest 4: Invalid tab ID (error handling)');
   try {
-    const response4 = await sendCommand('tabs.getAccessibilitySnapshot', {
+    await sendCommand('tabs.getAccessibilitySnapshot', {
       tabId: 99999
     });
     console.log('✗ Should have failed with invalid tab ID');

--- a/test-accessibility.html
+++ b/test-accessibility.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Accessibility Snapshot Test Page</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .hidden {
+            display: none;
+        }
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0,0,0,0);
+            white-space: nowrap;
+            border: 0;
+        }
+        #result {
+            margin-top: 20px;
+            padding: 10px;
+            background: #f0f0f0;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font-family: monospace;
+            white-space: pre-wrap;
+            max-height: 400px;
+            overflow-y: auto;
+        }
+    </style>
+</head>
+<body>
+    <header role="banner">
+        <h1>Accessibility Snapshot Test</h1>
+    </header>
+    
+    <nav role="navigation" aria-label="Main navigation">
+        <ul>
+            <li><a href="#home">Home</a></li>
+            <li><a href="#about">About</a></li>
+            <li><a href="#contact">Contact</a></li>
+        </ul>
+    </nav>
+    
+    <main role="main" id="main-content">
+        <article>
+            <h2>Test Form</h2>
+            <form aria-label="Contact form">
+                <div>
+                    <label for="name">Name:</label>
+                    <input type="text" id="name" name="name" required aria-required="true">
+                </div>
+                
+                <div>
+                    <label for="email">Email:</label>
+                    <input type="email" id="email" name="email" required aria-required="true" value="test@example.com">
+                </div>
+                
+                <div>
+                    <input type="checkbox" id="subscribe" name="subscribe" checked>
+                    <label for="subscribe">Subscribe to newsletter</label>
+                </div>
+                
+                <fieldset>
+                    <legend>Preferred Contact Method</legend>
+                    <input type="radio" id="contact-email" name="contact" value="email" checked>
+                    <label for="contact-email">Email</label>
+                    <br>
+                    <input type="radio" id="contact-phone" name="contact" value="phone">
+                    <label for="contact-phone">Phone</label>
+                </fieldset>
+                
+                <button type="submit" aria-label="Submit form">Submit</button>
+                <button type="button" aria-expanded="false" aria-controls="more-options">More Options</button>
+            </form>
+        </article>
+        
+        <div id="more-options" class="hidden">
+            <h3>Additional Options</h3>
+            <p>These are additional options that can be shown/hidden.</p>
+        </div>
+        
+        <div aria-hidden="true" class="hidden">
+            <p>This content should not appear in accessibility tree</p>
+        </div>
+        
+        <div class="sr-only">
+            <p>This is screen reader only content</p>
+        </div>
+    </main>
+    
+    <footer role="contentinfo">
+        <p>&copy; 2024 Test Page</p>
+    </footer>
+    
+    <div id="result">
+        <h3>Test Results</h3>
+        <p>Open the browser console and run the extension's accessibility snapshot function to see results here.</p>
+    </div>
+    
+    <script>
+        // Helper to display results
+        window.displayAccessibilitySnapshot = function(snapshot) {
+            const resultDiv = document.getElementById('result');
+            resultDiv.innerHTML = '<h3>Accessibility Snapshot Result:</h3>' +
+                '<pre>' + JSON.stringify(snapshot, null, 2) + '</pre>';
+        };
+        
+        // Test the toggle button
+        document.querySelector('[aria-controls="more-options"]').addEventListener('click', function() {
+            const expanded = this.getAttribute('aria-expanded') === 'true';
+            this.setAttribute('aria-expanded', !expanded);
+            document.getElementById('more-options').classList.toggle('hidden');
+        });
+    </script>
+</body>
+</html>

--- a/test-extension-commands.html
+++ b/test-extension-commands.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Extension Commands</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .test-section {
+            margin: 20px 0;
+            padding: 15px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+        button {
+            margin: 5px;
+            padding: 10px 15px;
+            cursor: pointer;
+        }
+        #output {
+            margin-top: 20px;
+            padding: 15px;
+            background: #f5f5f5;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            font-family: monospace;
+            white-space: pre-wrap;
+            max-height: 400px;
+            overflow-y: auto;
+        }
+        .success {
+            color: green;
+        }
+        .error {
+            color: red;
+        }
+    </style>
+</head>
+<body>
+    <h1>Extension Command Tester</h1>
+    
+    <div class="test-section">
+        <h2>Test Accessibility Snapshot</h2>
+        <p>Open the browser console (F12) and run these commands to test the accessibility snapshot:</p>
+        
+        <h3>1. Get current tab ID:</h3>
+        <pre>chrome.tabs.query({active: true, currentWindow: true}, (tabs) => console.log('Current tab ID:', tabs[0].id));</pre>
+        
+        <h3>2. Test basic accessibility snapshot:</h3>
+        <pre>// Replace TAB_ID with your actual tab ID
+chrome.runtime.sendMessage({
+  type: 'command',
+  command: 'tabs.getAccessibilitySnapshot',
+  params: { tabId: TAB_ID }
+}, response => console.log('Accessibility snapshot:', response));</pre>
+        
+        <h3>3. Direct script execution test:</h3>
+        <pre>chrome.scripting.executeScript({
+  target: { tabId: TAB_ID },
+  func: () => {
+    // Test if we can access the page
+    return {
+      title: document.title,
+      hasBody: !!document.body,
+      elementsCount: document.querySelectorAll('*').length
+    };
+  }
+}, results => console.log('Page info:', results[0].result));</pre>
+    </div>
+    
+    <div class="test-section">
+        <h2>Test Page Content</h2>
+        <p>This section contains various elements to test accessibility:</p>
+        
+        <button onclick="log('Button clicked')">Test Button</button>
+        <button disabled>Disabled Button</button>
+        <button aria-expanded="false" aria-controls="details">Toggle Details</button>
+        
+        <div id="details" style="display: none;">
+            <p>Hidden details section</p>
+        </div>
+        
+        <form>
+            <label for="test-input">Test Input:</label>
+            <input type="text" id="test-input" value="Test value" required>
+            
+            <label for="test-checkbox">
+                <input type="checkbox" id="test-checkbox" checked> Test Checkbox
+            </label>
+        </form>
+        
+        <nav aria-label="Test navigation">
+            <ul>
+                <li><a href="#section1">Section 1</a></li>
+                <li><a href="#section2">Section 2</a></li>
+            </ul>
+        </nav>
+    </div>
+    
+    <div id="output">
+        <h3>Console Output:</h3>
+        <p>Output will appear here...</p>
+    </div>
+    
+    <script>
+        function log(message, isError = false) {
+            const output = document.getElementById('output');
+            const timestamp = new Date().toLocaleTimeString();
+            const className = isError ? 'error' : 'success';
+            output.innerHTML += `<span class="${className}">[${timestamp}] ${message}</span>\n`;
+        }
+        
+        // Toggle button functionality
+        document.querySelector('[aria-controls="details"]').addEventListener('click', function() {
+            const expanded = this.getAttribute('aria-expanded') === 'true';
+            this.setAttribute('aria-expanded', !expanded);
+            document.getElementById('details').style.display = expanded ? 'none' : 'block';
+        });
+        
+        // Log when page loads
+        window.addEventListener('load', () => {
+            log('Page loaded. Open browser console (F12) to test extension commands.');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Improved error handling when content script cannot initialize on restricted pages
- Added comprehensive test files for the accessibility snapshot functionality
- Changed error logging to warnings for better developer experience

## Changes
1. **Enhanced content script initialization (`content.js`)**
   - Changed `console.error` to `console.warn` for extension context unavailability
   - Added explicit checks for restricted protocols (chrome://, edge://, about://, etc.)
   - Provides clearer feedback when content scripts cannot run on certain pages

2. **Added test files**
   - `test-accessibility.html`: Comprehensive test page with various accessibility elements including forms, ARIA attributes, and navigation
   - `test-accessibility-snapshot.js`: Example test script showing how to use the accessibility snapshot API
   - `test-extension-commands.html`: Manual testing instructions and console commands for developers

## Test plan
- [x] Load the extension and visit a restricted page (e.g., chrome://extensions)
- [x] Verify that a warning (not error) appears in the console
- [x] Open test-accessibility.html in a regular tab
- [x] Use the console commands from test-extension-commands.html to test the accessibility snapshot
- [x] Verify that the accessibility tree is correctly generated with roles, names, and properties