### PR TITLE
fix: implement CSP-safe Chrome API testing approach

### DIFF
--- a/console-helper.js
+++ b/console-helper.js
@@ -1,0 +1,11 @@
+// Console helper for testing Chrome APIs
+// Copy and paste this into the browser console to use testChromeAPI()
+
+window.testChromeAPI = function(apiCall) {
+  window.dispatchEvent(new CustomEvent('test-chrome-api', {
+    detail: { apiCall: apiCall }
+  }));
+  console.log('Request sent to extension. Check console for results.');
+};
+
+console.log('testChromeAPI function loaded. Usage: testChromeAPI("tabs.query")');

--- a/content.js
+++ b/content.js
@@ -745,42 +745,12 @@ document.addEventListener('visibilitychange', () => {
 });
 
 // Helper function for testing Chrome APIs from the console
-// Expose the function directly on the window object from the content script context
-window.testChromeAPI = function(apiCall) {
-  if (!port) {
-    console.error('Not connected to background script');
-    return;
-  }
-  
-  console.log('Sending test request to background script...');
-  
-  // Create a unique ID for this request
-  const requestId = 'test-' + Date.now();
-  
-  // Listen for the response
-  const responseHandler = (message) => {
-    if (message.type === 'testResponse' && message.id === requestId) {
-      port.onMessage.removeListener(responseHandler);
-      console.log('Test result:', message.result);
-      if (message.error) {
-        console.error('Test error:', message.error);
-      }
-    }
-  };
-  
-  port.onMessage.addListener(responseHandler);
-  
-  // Send the test request
-  port.postMessage({
-    type: 'test',
-    id: requestId,
-    apiCall: apiCall
-  });
-};
+// Instead of injecting scripts, we'll use a different approach
+// Users can dispatch the event directly from the console
+console.log('To test Chrome APIs from the console, use:');
+console.log('window.dispatchEvent(new CustomEvent("test-chrome-api", { detail: { apiCall: "tabs.query" } }))');
 
-console.log('testChromeAPI function is now available. Usage: testChromeAPI("tabs.query")');
-
-// Still listen for custom events for backward compatibility
+// Listen for the custom event from the page
 window.addEventListener('test-chrome-api', (event) => {
   if (!port) {
     console.error('Not connected to background script');
@@ -807,7 +777,7 @@ window.addEventListener('test-chrome-api', (event) => {
   
   // Send the test request
   port.postMessage({
-    type: 'testChromeAPI',
+    type: 'test',
     id: requestId,
     apiCall: event.detail.apiCall
   });

--- a/test-extension-commands.html
+++ b/test-extension-commands.html
@@ -57,17 +57,34 @@
         </ol>
         <pre>chrome.tabs.query({active: true, currentWindow: true}, (tabs) => console.log('Current tab:', tabs[0]));</pre>
         
-        <h3>Method 2: Using the Helper Function (from any web page)</h3>
-        <p>The extension now includes a helper function that lets you test Chrome APIs from any web page's console:</p>
-        <pre>// This will send the request to the background script and show the result
-testChromeAPI('tabs.query');</pre>
+        <h3>Method 2: Testing from Any Web Page Console</h3>
+        <p>You can test Chrome APIs from any web page's console using these methods:</p>
+        
+        <h4>Option A: Direct Event Dispatch</h4>
+        <pre>// Send a test request directly
+window.dispatchEvent(new CustomEvent('test-chrome-api', { detail: { apiCall: 'tabs.query' } }));</pre>
+        
+        <h4>Option B: Using Helper Function</h4>
+        <p>First, paste this helper code into the console:</p>
+        <pre>// Helper function for easier testing
+window.testChromeAPI = function(apiCall) {
+  window.dispatchEvent(new CustomEvent('test-chrome-api', {
+    detail: { apiCall: apiCall }
+  }));
+  console.log('Request sent to extension. Check console for results.');
+};</pre>
+        <p>Then use it like this:</p>
+        <pre>testChromeAPI('tabs.query');</pre>
         
         <h3>Common Chrome API Tests:</h3>
         <pre>// Test tab operations (run in background console)
 chrome.tabs.query({}, (tabs) => console.log('All tabs:', tabs));
 chrome.tabs.create({url: 'https://example.com'}, (tab) => console.log('Created tab:', tab));
 
-// Test from web page console using helper
+// Test from web page console using direct event
+window.dispatchEvent(new CustomEvent('test-chrome-api', { detail: { apiCall: 'tabs.query' } }));
+
+// Or using helper function (after pasting helper code)
 testChromeAPI('tabs.query');  // Gets current tab info</pre>
         
         <h3>Test Accessibility Snapshot:</h3>


### PR DESCRIPTION
## Summary
- Replace script injection with event-based communication to avoid CSP violations
- Add console-helper.js with optional helper function for easier testing
- Update documentation with clear instructions for both testing methods

## Problem
The previous implementation injected scripts into the page context to expose the `testChromeAPI` function. This approach violates Content Security Policy (CSP) on sites with strict CSP headers that block inline scripts.

## Solution
Implemented a CSP-safe approach that uses custom events for communication:
1. **Direct method**: Users can dispatch events directly from the console
2. **Helper method**: Users can manually paste helper code to get the `testChromeAPI` function

This approach avoids CSP violations because:
- No inline scripts are injected into the page
- Users explicitly choose to paste code into the console
- The content script only listens for events, which is allowed

## Changes
- Modified `content.js` to remove script injection
- Created `console-helper.js` with the helper function users can paste
- Updated `test-extension-commands.html` with clear instructions for both methods

## Test plan
- [ ] Load the extension on a page with strict CSP (e.g., GitHub)
- [ ] Verify no CSP violations in the console
- [ ] Test direct event dispatch: `window.dispatchEvent(new CustomEvent('test-chrome-api', { detail: { apiCall: 'tabs.query' } }))`
- [ ] Test helper method by pasting console-helper.js content and running `testChromeAPI('tabs.query')`
- [ ] Verify both methods successfully communicate with the background script