### PR TITLE
Fix content script restrictions and Gmail compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["http://*/*", "https://*/*"],
       "js": ["content.js"],
       "run_at": "document_start",
       "all_frames": true,


### PR DESCRIPTION
## Summary
- Fixed content script injection errors on restricted pages (about:, chrome:, etc.)
- Improved Gmail compatibility by handling dynamic content loading
- Ensured accessibility snapshot always returns valid data

## Changes Made

### 1. Updated manifest.json
- Changed content script matches from `<all_urls>` to `["http://*/*", "https://*/*"]`
- This prevents Chrome from attempting to inject content scripts into restricted pages

### 2. Enhanced getAccessibilitySnapshot function
- Added checks for document.body availability (for SPAs)
- Added retry logic for empty body content (common during Gmail initial load)
- Falls back to showing all content if no "interesting" content is found
- Always returns a valid snapshot structure instead of null

### 3. Fixed visibility change handler
- Moved console log after protocol validation
- Prevents misleading "attempting to connect" message on restricted pages

## Test plan
- [ ] Load the extension and navigate to an about: page (e.g., about:blank)
- [ ] Verify only "Content script cannot run on about: pages" warning appears
- [ ] Navigate to Gmail and test getAccessibilitySnapshot
- [ ] Verify snapshot returns valid data after Gmail loads
- [ ] Test on regular http/https pages to ensure normal functionality