### PR TITLE
feat: implement tabs.sendKey command

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
-  testMatch: ['<rootDir>/tests/simple.test.js', '<rootDir>/tests/waitForElement.test.js', '<rootDir>/tests/getActionables.test.js', '<rootDir>/tests/accessibilitySnapshot.test.js', '<rootDir>/tests/scroll.test.js'],
+  testMatch: ['<rootDir>/tests/simple.test.js', '<rootDir>/tests/waitForElement.test.js', '<rootDir>/tests/getActionables.test.js', '<rootDir>/tests/accessibilitySnapshot.test.js', '<rootDir>/tests/scroll.test.js', '<rootDir>/tests/sendKey.test.js'],
   collectCoverageFrom: [
     '*.js',
     '!example-websocket-server.js',

--- a/test-extension-commands.html
+++ b/test-extension-commands.html
@@ -94,6 +94,28 @@ chrome.runtime.sendMessage({
   command: 'tabs.getAccessibilitySnapshot',
   params: { tabId: TAB_ID }
 }, response => console.log('Accessibility snapshot:', response));</pre>
+        
+        <h3>Test Send Key Command:</h3>
+        <pre>// Send a single key to the focused element
+chrome.runtime.sendMessage({
+  type: 'command',
+  command: 'tabs.sendKey',
+  params: { tabId: TAB_ID, key: 'a' }
+}, response => console.log('SendKey result:', response));
+
+// Send key to specific element
+chrome.runtime.sendMessage({
+  type: 'command',
+  command: 'tabs.sendKey',
+  params: { tabId: TAB_ID, selector: '#test-input', key: 'Enter' }
+}, response => console.log('SendKey result:', response));
+
+// Send key with modifiers (Ctrl+A to select all)
+chrome.runtime.sendMessage({
+  type: 'command',
+  command: 'tabs.sendKey',
+  params: { tabId: TAB_ID, selector: '#test-input', key: 'a', modifiers: ['ctrl'] }
+}, response => console.log('SendKey result:', response));</pre>
     </div>
     
     <div class="test-section">

--- a/tests/sendKey.test.js
+++ b/tests/sendKey.test.js
@@ -20,6 +20,9 @@ describe('tabs.sendKey', () => {
   test('should send key to focused element', async () => {
     require('../background.js');
     await server.connected;
+    
+    // Skip the initial connected message
+    await server.nextMessage;
 
     // Mock Chrome API
     chrome.scripting.executeScript.mockResolvedValueOnce([{ 
@@ -35,7 +38,7 @@ describe('tabs.sendKey', () => {
     const message = await server.nextMessage;
     const response = JSON.parse(message);
     
-    expect(response.result.success).toBe(true);
+    expect(response.result).toEqual({ success: true });
     expect(chrome.scripting.executeScript).toHaveBeenCalledWith({
       target: { tabId: 1 },
       func: expect.any(Function),
@@ -46,6 +49,9 @@ describe('tabs.sendKey', () => {
   test('should send key to specific element', async () => {
     require('../background.js');
     await server.connected;
+    
+    // Skip the initial connected message
+    await server.nextMessage;
 
     chrome.scripting.executeScript.mockResolvedValueOnce([{ 
       result: { success: true }
@@ -64,7 +70,7 @@ describe('tabs.sendKey', () => {
     const message = await server.nextMessage;
     const response = JSON.parse(message);
     
-    expect(response.result.success).toBe(true);
+    expect(response.result).toEqual({ success: true });
     expect(chrome.scripting.executeScript).toHaveBeenCalledWith({
       target: { tabId: 1 },
       func: expect.any(Function),
@@ -75,6 +81,9 @@ describe('tabs.sendKey', () => {
   test('should send key with modifiers', async () => {
     require('../background.js');
     await server.connected;
+    
+    // Skip the initial connected message
+    await server.nextMessage;
 
     chrome.scripting.executeScript.mockResolvedValueOnce([{ 
       result: { success: true }
@@ -93,7 +102,7 @@ describe('tabs.sendKey', () => {
     const message = await server.nextMessage;
     const response = JSON.parse(message);
     
-    expect(response.result.success).toBe(true);
+    expect(response.result).toEqual({ success: true });
     expect(chrome.scripting.executeScript).toHaveBeenCalledWith({
       target: { tabId: 1 },
       func: expect.any(Function),
@@ -104,6 +113,9 @@ describe('tabs.sendKey', () => {
   test('should handle element not found', async () => {
     require('../background.js');
     await server.connected;
+    
+    // Skip the initial connected message
+    await server.nextMessage;
 
     chrome.scripting.executeScript.mockResolvedValueOnce([{ 
       result: { success: false, error: 'No element found' }
@@ -122,13 +134,15 @@ describe('tabs.sendKey', () => {
     const message = await server.nextMessage;
     const response = JSON.parse(message);
     
-    expect(response.result.success).toBe(false);
-    expect(response.result.error).toBe('No element found');
+    expect(response.result).toEqual({ success: false, error: 'No element found' });
   });
 
   test('should handle script execution failure', async () => {
     require('../background.js');
     await server.connected;
+    
+    // Skip the initial connected message
+    await server.nextMessage;
 
     chrome.scripting.executeScript.mockResolvedValueOnce([null]);
 
@@ -144,7 +158,6 @@ describe('tabs.sendKey', () => {
     const message = await server.nextMessage;
     const response = JSON.parse(message);
     
-    expect(response.result.success).toBe(false);
-    expect(response.result.error).toBe('Script execution failed');
+    expect(response.result).toEqual({ success: false, error: 'Script execution failed' });
   });
 });

--- a/tests/sendKey.test.js
+++ b/tests/sendKey.test.js
@@ -1,0 +1,150 @@
+const WS = require('jest-websocket-mock').default;
+
+describe('tabs.sendKey', () => {
+  let server;
+
+  beforeEach(async () => {
+    server = new WS('ws://localhost:8765');
+    jest.resetModules();
+    global.wsConnection = null;
+    global.wsReconnectInterval = null;
+  });
+
+  afterEach(() => {
+    WS.clean();
+    if (global.wsReconnectInterval) {
+      clearInterval(global.wsReconnectInterval);
+    }
+  });
+
+  test('should send key to focused element', async () => {
+    require('../background.js');
+    await server.connected;
+
+    // Mock Chrome API
+    chrome.scripting.executeScript.mockResolvedValueOnce([{ 
+      result: { success: true }
+    }]);
+
+    server.send(JSON.stringify({
+      id: '1',
+      command: 'tabs.sendKey',
+      params: { tabId: 1, key: 'a' }
+    }));
+
+    const message = await server.nextMessage;
+    const response = JSON.parse(message);
+    
+    expect(response.result.success).toBe(true);
+    expect(chrome.scripting.executeScript).toHaveBeenCalledWith({
+      target: { tabId: 1 },
+      func: expect.any(Function),
+      args: [undefined, 'a', undefined]
+    });
+  });
+
+  test('should send key to specific element', async () => {
+    require('../background.js');
+    await server.connected;
+
+    chrome.scripting.executeScript.mockResolvedValueOnce([{ 
+      result: { success: true }
+    }]);
+
+    server.send(JSON.stringify({
+      id: '2',
+      command: 'tabs.sendKey',
+      params: { 
+        tabId: 1, 
+        selector: '#username',
+        key: 'Enter' 
+      }
+    }));
+
+    const message = await server.nextMessage;
+    const response = JSON.parse(message);
+    
+    expect(response.result.success).toBe(true);
+    expect(chrome.scripting.executeScript).toHaveBeenCalledWith({
+      target: { tabId: 1 },
+      func: expect.any(Function),
+      args: ['#username', 'Enter', undefined]
+    });
+  });
+
+  test('should send key with modifiers', async () => {
+    require('../background.js');
+    await server.connected;
+
+    chrome.scripting.executeScript.mockResolvedValueOnce([{ 
+      result: { success: true }
+    }]);
+
+    server.send(JSON.stringify({
+      id: '3',
+      command: 'tabs.sendKey',
+      params: { 
+        tabId: 1, 
+        key: 'a',
+        modifiers: ['ctrl', 'shift']
+      }
+    }));
+
+    const message = await server.nextMessage;
+    const response = JSON.parse(message);
+    
+    expect(response.result.success).toBe(true);
+    expect(chrome.scripting.executeScript).toHaveBeenCalledWith({
+      target: { tabId: 1 },
+      func: expect.any(Function),
+      args: [undefined, 'a', ['ctrl', 'shift']]
+    });
+  });
+
+  test('should handle element not found', async () => {
+    require('../background.js');
+    await server.connected;
+
+    chrome.scripting.executeScript.mockResolvedValueOnce([{ 
+      result: { success: false, error: 'No element found' }
+    }]);
+
+    server.send(JSON.stringify({
+      id: '4',
+      command: 'tabs.sendKey',
+      params: { 
+        tabId: 1,
+        selector: '#nonexistent',
+        key: 'x'
+      }
+    }));
+
+    const message = await server.nextMessage;
+    const response = JSON.parse(message);
+    
+    expect(response.result.success).toBe(false);
+    expect(response.result.error).toBe('No element found');
+  });
+
+  test('should handle script execution failure', async () => {
+    require('../background.js');
+    await server.connected;
+
+    chrome.scripting.executeScript.mockResolvedValueOnce([null]);
+
+    server.send(JSON.stringify({
+      id: '5',
+      command: 'tabs.sendKey',
+      params: { 
+        tabId: 1,
+        key: 'a'
+      }
+    }));
+
+    const message = await server.nextMessage;
+    const response = JSON.parse(message);
+    
+    expect(response.result.success).toBe(false);
+    expect(response.result.error).toBe('Script execution failed');
+  });
+});


### PR DESCRIPTION
## Summary
- Implements the `tabs.sendKey` command for sending keyboard events to web page elements
- Adds support for keyboard modifiers (ctrl, alt, shift, meta)
- Includes comprehensive test coverage

## Implementation Details
The `tabs.sendKey` command allows sending keyboard events to either the currently focused element or a specific element identified by a CSS selector. It supports:

1. **Basic key sending**: Send any key to an element
2. **Modifier keys**: Support for ctrl, alt, shift, and meta modifiers
3. **Proper event sequence**: Dispatches keydown, keypress (for printable characters), and keyup events
4. **Input/textarea handling**: Automatically updates the value for form inputs

## Usage Examples
```javascript
// Send a key to the focused element
tabs.sendKey({ tabId: 1, key: 'a' })

// Send Enter key to a specific element
tabs.sendKey({ tabId: 1, selector: '#submit-button', key: 'Enter' })

// Send Ctrl+A (select all)
tabs.sendKey({ tabId: 1, selector: '#text-input', key: 'a', modifiers: ['ctrl'] })
```

## Test Plan
- [x] Unit tests added for all functionality
- [ ] Manual testing with the test extension page
- [ ] Test with different element types (input, textarea, buttons)
- [ ] Test modifier key combinations
- [ ] Test special keys (Enter, Tab, Escape, etc.)